### PR TITLE
ig-traces: Fix TraceIcon pod object reference

### DIFF
--- a/plugins/ig-traces/src/index.js
+++ b/plugins/ig-traces/src/index.js
@@ -270,13 +270,15 @@ function TraceIcon(props) {
         continue;
       }
 
-      const itemTrace = getIGPodTraces(pod).find(({podname, namespace}) =>
+      let podObj = new K8s.Pod(pod)
+
+      const itemTrace = getIGPodTraces(podObj).find(({podname, namespace}) =>
         item.metadata.name === podname && item.metadata.namespace === namespace);
       if (!!itemTrace) {
         if (!!trace && trace.traceid === itemTrace.traceid) {
           return;
         }
-        setIGPod(pod);
+        setIGPod(podObj);
         setTrace(itemTrace);
         break;
       }


### PR DESCRIPTION
The mentioned component had not been updated when we started using pods
as Pod class instances, but the code to exec into the pod was expecting
it to be a Pod class instance. So the icon functionality for viewing
the traces was completely broken.

This patch fixes that by simply using the pod object as a Pod instance.