### PR TITLE
Update mentions of the master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
       uses: actions/checkout@v2
     - name: Set up Lokomotive Web UI
       run: |
-        ./build.sh --branch master -n
+        ./build.sh --branch main -n

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ EOF
 TOP_DIR=$(realpath "./$(dirname ${BASH_SOURCE[0]})")
 BUILD_DIR=
 REPO="https://github.com/kinvolk/headlamp.git"
-BRANCH=master
+BRANCH=main
 PLUGINS_SRC_DIR="$TOP_DIR/plugins"
 PLUGINS=$(ls ${PLUGINS_SRC_DIR})
 DRY_RUN=


### PR DESCRIPTION
We've changed the default branch in Headlamp and Lokomotive Web UI to
"main" recently.
