### PR TITLE
ig-traces: Check whether IG pods exist before using them

### DIFF
--- a/plugins/ig-traces/src/index.js
+++ b/plugins/ig-traces/src/index.js
@@ -145,6 +145,10 @@ function TraceList() {
   const classes = useStyle();
 
   function setIGPods(items) {
+    if (!items) {
+      return;
+    }
+
     const igPods = items.filter(item => isIGPod(item));
     setTraces(getAllTraces(igPods));
   }


### PR DESCRIPTION
This avoids calling a function on null.
